### PR TITLE
fix netcdf4 for latest pyodide

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -1,5 +1,7 @@
 import micropip
 await micropip.install("requests")
+await micropip.install("netcdf4")
+
 from js import document
 from pyodide.ffi import create_proxy
 import compliance_checker


### PR DESCRIPTION
We should probably pin pyodide to avoid errors like this one, but it  seems that the latest version changed what packages are readily available. We need to micropip install netcdf4 now:

```
Traceback (most recent call last):
  File "/lib/python312.zip/_pyodide/_base.py", line 597, in eval_code_async
    await CodeRunner(
  File "/lib/python312.zip/_pyodide/_base.py", line 413, in run_async
    await coroutine
  File "<exec>", line 6, in <module>
  File "/lib/python3.12/site-packages/compliance_checker/runner.py", line 8, in <module>
    from compliance_checker.suite import CheckSuite
  File "/lib/python3.12/site-packages/compliance_checker/suite.py", line 23, in <module>
    from netCDF4 import Dataset
ModuleNotFoundError: No module named 'netCDF4'
The module 'netcdf4' is included in the Pyodide distribution, but it is not installed.
You can install it by calling:
  await micropip.install("netcdf4") in Python, or
  await pyodide.loadPackage("netcdf4") in JavaScript
See https://pyodide.org/en/stable/usage/loading-packages.html for more details.
````